### PR TITLE
fix profiles dna address mismatch issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+my-conductor-config.toml
+profiles_dna_address
 dna
 dist
 node_modules/

--- a/conductor-config.toml
+++ b/conductor-config.toml
@@ -12,7 +12,7 @@ test_agent = true
 
 [[dnas]]
 file = './dnas/profiles/dist/profiles.dna.json'
-hash = 'QmdGgs8UFtqyV9ed7offX4znEEdZJ3QXEfUjCjBQ44Dbyv'
+hash = 'QmTT6oSPHNFn4x9ssBM14M1HznLVGjrFKCyBcsTyBudzfg'
 id = 'profiles-dna'
 
 [[instances]]

--- a/nix/holochain/default.nix
+++ b/nix/holochain/default.nix
@@ -3,7 +3,12 @@ let
   acorn-hc = pkgs.writeShellScriptBin "acorn-hc"
   ''
   set -euxo pipefail
-  holochain -c ./conductor-config.toml
+  # don't error if it doesn't exist to remove
+  rm --force my-conductor-config.toml
+  cp conductor-config.toml my-conductor-config.toml
+  hc hash --path dnas/profiles/dist/profiles.dna.json | awk '/DNA Hash: /{print $NF}' | tr -d '\n' > profiles_dna_address
+  node update-dna-address.js
+  holochain -c ./my-conductor-config.toml
   '';
 
   acorn-fmt = pkgs.writeShellScriptBin "acorn-fmt"

--- a/update-dna-address.js
+++ b/update-dna-address.js
@@ -1,0 +1,20 @@
+const path = require('path')
+const fs = require('fs')
+
+// overwrite the DNA hash address in the conductor-config
+// with the up to date one
+const DNA_ADDRESS_FILE = 'profiles_dna_address'
+const CONDUCTOR_CONFIG_FILE = 'my-conductor-config.toml'
+
+const dnaAddress = fs.readFileSync(path.join(__dirname, DNA_ADDRESS_FILE))
+// read from the local template
+const origConductorConfigPath = path.join(__dirname, CONDUCTOR_CONFIG_FILE)
+const conductorConfig = fs.readFileSync(origConductorConfigPath).toString()
+
+// replace dna
+let newConductorConfig = conductorConfig.replace(
+  /hash = '\w+'/g,
+  `hash = '${dnaAddress}'`
+)
+
+fs.writeFileSync(origConductorConfigPath, newConductorConfig)


### PR DESCRIPTION
closes #91 

creates a new conductor config for dynamically changing the DNA hash, and adding Projects/Instances, so that original can stay checked in to git and represents the canonical copy