### PR TITLE
setup for acorn-ui, since Holoscape related updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-my-conductor-config.toml
+conductor-config.toml
 profiles_dna_address
 dna
 dist

--- a/nix/holochain/default.nix
+++ b/nix/holochain/default.nix
@@ -4,11 +4,11 @@ let
   ''
   set -euxo pipefail
   # don't error if it doesn't exist to remove
-  rm --force my-conductor-config.toml
-  cp conductor-config.toml my-conductor-config.toml
+  rm --force conductor-config.toml
+  cp starter.conductor-config.toml conductor-config.toml
   hc hash --path dnas/profiles/dist/profiles.dna.json | awk '/DNA Hash: /{print $NF}' | tr -d '\n' > profiles_dna_address
   node update-dna-address.js
-  holochain -c ./my-conductor-config.toml
+  holochain -c ./conductor-config.toml
   '';
 
   acorn-fmt = pkgs.writeShellScriptBin "acorn-fmt"

--- a/starter.conductor-config.toml
+++ b/starter.conductor-config.toml
@@ -1,10 +1,8 @@
 bridges = []
 persistence_dir = '.'
-ui_bundles = []
-ui_interfaces = []
 
 [[agents]]
-id = 'development-agent'
+id = 'acorn-profiles-instance-agent'
 keystore_file = 'unused'
 name = 'acorn user'
 public_address = 'HcScIc8G7X769Nr6cnRxgR73wi8au946z7hc46EMDJjaz8au4bD7V6hj7T6B8fa'
@@ -13,26 +11,39 @@ test_agent = true
 [[dnas]]
 file = './dnas/profiles/dist/profiles.dna.json'
 hash = 'QmTT6oSPHNFn4x9ssBM14M1HznLVGjrFKCyBcsTyBudzfg'
-id = 'profiles-dna'
+id = 'acorn-profiles-dna'
 
 [[instances]]
-agent = 'development-agent'
-dna = 'profiles-dna'
-id = 'profiles-instance'
+agent = 'acorn-profiles-instance-agent'
+dna = 'acorn-profiles-dna'
+id = 'acorn-profiles-instance'
 
 [instances.storage]
 type = 'memory'
 
 [[interfaces]]
 admin = true
-id = 'websocket-interface'
+id = 'Acorn-interface'
 
 [[interfaces.instances]]
-id = 'profiles-instance'
+id = 'acorn-profiles-instance'
 
 [interfaces.driver]
 port = 8888
 type = 'websocket'
+
+[[ui_bundles]]
+hash = 'QmTT6oSPHNFn4x9ssBM14M1HznLVGjrFKCyBcsTyBudzfg'
+id = 'dna-connections'
+root_dir = './irrelevant'
+
+[[ui_interfaces]]
+bind_address = '127.0.0.1'
+bundle = 'dna-connections'
+dna_interface = 'Acorn-interface'
+id = 'dna-connections-interface'
+port = 3111
+reroute_to_root = true
 
 [logger]
 state_dump = false

--- a/update-dna-address.js
+++ b/update-dna-address.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 // overwrite the DNA hash address in the conductor-config
 // with the up to date one
 const DNA_ADDRESS_FILE = 'profiles_dna_address'
-const CONDUCTOR_CONFIG_FILE = 'my-conductor-config.toml'
+const CONDUCTOR_CONFIG_FILE = 'conductor-config.toml'
 
 const dnaAddress = fs.readFileSync(path.join(__dirname, DNA_ADDRESS_FILE))
 // read from the local template


### PR DESCRIPTION
conductor-config.toml will always be written so switch initial and later toml

enable a "ui_interface" which will be used to reveal the main websocket interface. (since hc-web-client looks for this path `_dna_connections.json` if you leave a websocket url out)